### PR TITLE
Fix destination path resolving

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ const copyDir = (copyFrom, copyTo) => {
     fs.mkdirSync(copyTo, { recursive: true });
   }
   const copy = (filepath, relative, filename) => {
-    const dest = filepath.replace(copyFrom, copyTo);
+    const dest = path.join(copyTo, relative);
     if (!filename) {
       if (!fs.existsSync(dest)) {
         fs.mkdirSync(dest, { recursive: true });


### PR DESCRIPTION
Use the resolved destination path and relative path, rather than a string-replacement, which fails on windows environments, because `filepath.replace(copyFrom, copyTo)` does not play nice with '\'-characters.